### PR TITLE
fix(recipe): 修复工作台配方指纹全链路

### DIFF
--- a/core/src/main/java/pers/yufiria/craftorithm/recipe/RecipeFingerManager.java
+++ b/core/src/main/java/pers/yufiria/craftorithm/recipe/RecipeFingerManager.java
@@ -12,8 +12,14 @@ import pers.yufiria.craftorithm.item.ItemManager;
 import pers.yufiria.craftorithm.item.NamespacedItemId;
 import pers.yufiria.craftorithm.item.NamespacedItemIdStack;
 import pers.yufiria.craftorithm.recipe.util.RecipeFingerGenerator;
+import pers.yufiria.craftorithm.util.CollectionsUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -31,15 +37,23 @@ public enum RecipeFingerManager implements LifeCycleTask {
 
     INSTANCE;
 
-    /** 规范指纹 → 配方 Key（主查询表） */
-    private final Map<String, NamespacedKey> fingerToRecipeKey = new ConcurrentHashMap<>();
+    private static final int MAX_CANDIDATE_COMBINATIONS = 4096;
+
+    /** 规范指纹 → 按注册顺序保存的配方 Key（后注册优先） */
+    private final Map<String, List<NamespacedKey>> fingerToRecipeKeys = new ConcurrentHashMap<>();
 
     /** 配方 Key → 它注册的所有规范指纹（卸载时清理用） */
     private final Map<NamespacedKey, List<String>> recipeKeyToFingers = new ConcurrentHashMap<>();
 
+    /** 配方 Key → 它持有的 canonical 反查映射 */
+    private final Map<NamespacedKey, Set<RecipeFingerGenerator.CanonicalMapping>> recipeKeyToCanonicalMappings = new ConcurrentHashMap<>();
+
+    /** canonical 反查映射引用计数，避免移除一个配方时影响其他配方 */
+    private final Map<RecipeFingerGenerator.CanonicalMapping, Integer> canonicalMappingReferenceCounts = new ConcurrentHashMap<>();
+
     /**
-     * 具体物品 ID → 它所属的规范形式（反查表）。<p>
-     * 一个物品可能同时属于多个 tag，所以 value 是 Set。
+     * 具体物品 ID → 它所属的规范形式。<p>
+     * 一个物品可能同时属于多个 tag / itempack，所以 value 是 Set。
      */
     private final Map<String, Set<String>> concreteToCanonical = new ConcurrentHashMap<>();
 
@@ -48,50 +62,82 @@ public enum RecipeFingerManager implements LifeCycleTask {
     /**
      * 根据配方配置构建并注册指纹。
      *
-     * @param recipeKey  配方 NamespacedKey
+     * @param recipeKey 配方 NamespacedKey
      * @param recipeConfig 配方 YAML 配置
      */
     public void registerRecipeFinger(NamespacedKey recipeKey, YamlConfiguration recipeConfig) {
-        List<String> fingers = RecipeFingerGenerator.generateFingers(recipeConfig);
+        unregisterRecipeFinger(recipeKey);
+
+        RecipeFingerGenerator.GenerationResult generationResult = RecipeFingerGenerator.generate(recipeConfig);
+        List<String> fingers = generationResult.fingers().stream()
+            .distinct()
+            .toList();
         if (fingers.isEmpty()) {
             return;
         }
+
+        Set<RecipeFingerGenerator.CanonicalMapping> canonicalMappings = generationResult.canonicalMappings();
+        for (RecipeFingerGenerator.CanonicalMapping canonicalMapping : canonicalMappings) {
+            registerCanonicalMapping(canonicalMapping);
+        }
+        recipeKeyToCanonicalMappings.put(recipeKey, canonicalMappings);
+
         for (String finger : fingers) {
-            fingerToRecipeKey.put(finger, recipeKey);
+            registerFinger(finger, recipeKey);
         }
         recipeKeyToFingers.put(recipeKey, fingers);
     }
 
+    private void registerFinger(String finger, NamespacedKey recipeKey) {
+        fingerToRecipeKeys.compute(finger, (ignored, recipeKeys) -> {
+            List<NamespacedKey> updated = recipeKeys == null ? new ArrayList<>() : new ArrayList<>(recipeKeys);
+            updated.remove(recipeKey);
+            updated.add(recipeKey);
+            return List.copyOf(updated);
+        });
+    }
+
     /**
-     * 注销一个配方的所有指纹。
+     * 注销一个配方的所有指纹和 canonical 反查映射。
      */
     public void unregisterRecipeFinger(NamespacedKey recipeKey) {
         List<String> fingers = recipeKeyToFingers.remove(recipeKey);
         if (fingers != null) {
-            fingers.forEach(fingerToRecipeKey::remove);
+            for (String finger : fingers) {
+                fingerToRecipeKeys.computeIfPresent(finger, (ignored, recipeKeys) -> {
+                    List<NamespacedKey> updated = new ArrayList<>(recipeKeys);
+                    updated.remove(recipeKey);
+                    return updated.isEmpty() ? null : List.copyOf(updated);
+                });
+            }
+        }
+
+        Set<RecipeFingerGenerator.CanonicalMapping> canonicalMappings = recipeKeyToCanonicalMappings.remove(recipeKey);
+        if (canonicalMappings != null) {
+            canonicalMappings.forEach(this::unregisterCanonicalMapping);
         }
     }
 
     // ====================== 反查表 ======================
 
-    /**
-     * 注册一个具体物品到规范形式的反查映射。<p>
-     * 在解析 tag / itempack 配方材料时调用。
-     *
-     * @param concreteId    具体物品 ID，如 "minecraft:oak_planks"
-     * @param canonicalForm 规范形式，如 "tag:minecraft:planks"
-     */
-    public void registerCanonicalMapping(String concreteId, String canonicalForm) {
-        concreteToCanonical.computeIfAbsent(concreteId, k -> ConcurrentHashMap.newKeySet())
-            .add(canonicalForm);
+    private void registerCanonicalMapping(RecipeFingerGenerator.CanonicalMapping canonicalMapping) {
+        canonicalMappingReferenceCounts.merge(canonicalMapping, 1, Integer::sum);
+        concreteToCanonical.computeIfAbsent(canonicalMapping.concreteId(), ignored -> ConcurrentHashMap.newKeySet())
+            .add(canonicalMapping.canonicalForm());
     }
 
-    /**
-     * 获取一个具体物品 ID 对应的所有规范形式。<p>
-     * 如果没有注册过反查映射，返回空集合。
-     */
-    public Set<String> getCanonicalForms(String concreteId) {
-        return concreteToCanonical.getOrDefault(concreteId, Collections.emptySet());
+    private void unregisterCanonicalMapping(RecipeFingerGenerator.CanonicalMapping canonicalMapping) {
+        canonicalMappingReferenceCounts.computeIfPresent(canonicalMapping, (ignored, referenceCount) -> {
+            if (referenceCount > 1) {
+                return referenceCount - 1;
+            }
+
+            concreteToCanonical.computeIfPresent(canonicalMapping.concreteId(), (concreteId, canonicalForms) -> {
+                canonicalForms.remove(canonicalMapping.canonicalForm());
+                return canonicalForms.isEmpty() ? null : canonicalForms;
+            });
+            return null;
+        });
     }
 
     // ====================== 查询 ======================
@@ -99,85 +145,71 @@ public enum RecipeFingerManager implements LifeCycleTask {
     /**
      * 根据合成网格物品查找配方 Key。
      *
-     * @param matrix 合成网格（3x3，可能包含 null）
+     * @param matrix 合成网格（2x2 或 3x3，可能包含 null）
      * @return 匹配到的配方 Key，未匹配返回 null
      */
     public @Nullable NamespacedKey findRecipeByGrid(ItemStack[] matrix) {
-        // 转为二维列表
-        List<List<String>> grid = new ArrayList<>();
+        if (matrix == null || matrix.length == 0) {
+            return null;
+        }
+
+        List<List<String>> grid = toConcreteIdGrid(matrix);
+        if (grid.isEmpty()) {
+            return null;
+        }
+
+        CollectionsUtils.trimEmptyBorders(grid, Objects::isNull);
+        if (grid.isEmpty()) {
+            return null;
+        }
+
+        return findWithCandidateExpansion(grid);
+    }
+
+    private List<List<String>> toConcreteIdGrid(ItemStack[] matrix) {
         int cols = (int) Math.sqrt(matrix.length);
+        if (cols <= 0 || cols * cols != matrix.length) {
+            return List.of();
+        }
+
+        List<List<String>> grid = new ArrayList<>();
         for (int row = 0; row < cols; row++) {
             List<String> rowList = new ArrayList<>();
             for (int col = 0; col < cols; col++) {
                 ItemStack item = matrix[row * cols + col];
                 if (item == null || item.getType().isAir()) {
                     rowList.add(null);
-                } else {
-                    NamespacedItemIdStack idStack = ItemManager.INSTANCE.matchItemId(item, true);
-                    String concreteId;
-                    if (idStack != null) {
-                        concreteId = idStack.itemId().toString();
-                    } else {
-                        concreteId = NamespacedItemId.fromMaterial(item.getType()).toString();
-                    }
-                    rowList.add(concreteId);
+                    continue;
                 }
+
+                NamespacedItemIdStack idStack = ItemManager.INSTANCE.matchItemId(item, true).orElse(null);
+                String concreteId = idStack != null
+                    ? idStack.itemId().toString()
+                    : NamespacedItemId.fromMaterial(item.getType()).toString();
+                rowList.add(concreteId);
             }
             grid.add(rowList);
         }
+        return grid;
+    }
 
-        // 裁剪空行空列
-        pers.yufiria.craftorithm.util.CollectionsUtils.trimEmptyBorders(grid, Objects::isNull);
-
-        if (grid.isEmpty()) {
+    /**
+     * 对每个非空格子尝试“具体 ID + 所有规范形式”。<p>
+     * 具体 ID 永远先于 tag / itempack，避免更具体配方被宽泛材料覆盖。
+     */
+    private @Nullable NamespacedKey findWithCandidateExpansion(List<List<String>> grid) {
+        List<SlotCandidate> slots = collectSlotCandidates(grid);
+        if (slots.isEmpty()) {
             return null;
         }
 
-        // 尝试有序配方指纹（带坐标）
-        String finger = buildCanonicalFinger(grid);
-        NamespacedKey key = fingerToRecipeKey.get(finger);
-        if (key != null) {
-            return key;
-        }
-
-        // 尝试无序配方指纹（排序，无坐标）
-        String shapelessFinger = buildShapelessFinger(grid);
-        key = fingerToRecipeKey.get(shapelessFinger);
-        if (key != null) {
-            return key;
-        }
-
-        // fallback: 尝试每个格子的所有规范形式组合
-        return findWithCanonicalExpansion(grid);
+        String[] choices = new String[slots.size()];
+        int[] checkedCombinations = {0};
+        return findWithCandidateExpansion(slots, choices, 0, checkedCombinations);
     }
 
-    /**
-     * 用裁剪后的 grid 生成无序配方规范指纹（排序，无坐标）。
-     */
-    private String buildShapelessFinger(List<List<String>> grid) {
-        List<String> canonicals = new ArrayList<>();
-        for (List<String> row : grid) {
-            for (String concreteId : row) {
-                if (concreteId == null) {
-                    continue;
-                }
-                canonicals.add(toCanonicalForm(concreteId));
-            }
-        }
-        if (canonicals.isEmpty()) {
-            return "";
-        }
-        canonicals.sort(null);
-        return String.join("|", canonicals);
-    }
-
-    /**
-     * 用裁剪后的 grid 生成规范指纹（有序配方格式：带坐标）。
-     * 每个格子取第一个可用的规范形式。
-     */
-    private String buildCanonicalFinger(List<List<String>> grid) {
-        StringBuilder sb = new StringBuilder();
-        boolean first = true;
+    private List<SlotCandidate> collectSlotCandidates(List<List<String>> grid) {
+        List<SlotCandidate> slots = new ArrayList<>();
         for (int row = 0; row < grid.size(); row++) {
             List<String> rowList = grid.get(row);
             for (int col = 0; col < rowList.size(); col++) {
@@ -185,148 +217,104 @@ public enum RecipeFingerManager implements LifeCycleTask {
                 if (concreteId == null) {
                     continue;
                 }
-                if (!first) {
-                    sb.append('|');
-                }
-                first = false;
-                sb.append('<').append(row).append(',').append(col).append(',');
-                sb.append(toCanonicalForm(concreteId));
-                sb.append('>');
+                slots.add(new SlotCandidate(row, col, candidateForms(concreteId)));
             }
+        }
+        return slots;
+    }
+
+    private List<String> candidateForms(String concreteId) {
+        LinkedHashSet<String> forms = new LinkedHashSet<>();
+        forms.add(concreteId);
+
+        Set<String> canonicals = concreteToCanonical.get(concreteId);
+        if (canonicals != null && !canonicals.isEmpty()) {
+            canonicals.stream()
+                .sorted()
+                .forEach(forms::add);
+        }
+        return List.copyOf(forms);
+    }
+
+    private @Nullable NamespacedKey findWithCandidateExpansion(
+        List<SlotCandidate> slots,
+        String[] choices,
+        int slotIndex,
+        int[] checkedCombinations
+    ) {
+        if (checkedCombinations[0] >= MAX_CANDIDATE_COMBINATIONS) {
+            return null;
+        }
+
+        if (slotIndex >= slots.size()) {
+            checkedCombinations[0]++;
+            NamespacedKey key = findRecipeKey(buildShapedFinger(slots, choices));
+            if (key != null) {
+                return key;
+            }
+            return findRecipeKey(buildShapelessFinger(choices));
+        }
+
+        for (String candidate : slots.get(slotIndex).candidates()) {
+            choices[slotIndex] = candidate;
+            NamespacedKey key = findWithCandidateExpansion(slots, choices, slotIndex + 1, checkedCombinations);
+            if (key != null) {
+                return key;
+            }
+        }
+        return null;
+    }
+
+    private String buildShapedFinger(List<SlotCandidate> slots, String[] choices) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < slots.size(); i++) {
+            if (i > 0) {
+                sb.append('|');
+            }
+            SlotCandidate slot = slots.get(i);
+            sb.append('<')
+                .append(slot.row())
+                .append(',')
+                .append(slot.col())
+                .append(',')
+                .append(choices[i])
+                .append('>');
         }
         return sb.toString();
     }
 
-    /**
-     * 将具体物品 ID 转为规范形式。<p>
-     * 优先使用反查表中第一个匹配的规范形式，否则返回原 ID。
-     */
-    private String toCanonicalForm(String concreteId) {
-        Set<String> canonicals = concreteToCanonical.get(concreteId);
-        if (canonicals != null && !canonicals.isEmpty()) {
-            return canonicals.iterator().next();
-        }
-        return concreteId;
+    private String buildShapelessFinger(String[] choices) {
+        List<String> sorted = new ArrayList<>(List.of(choices));
+        sorted.sort(null);
+        return String.join("|", sorted);
     }
 
-    /**
-     * 当直接匹配失败时，尝试每个格子的所有规范形式组合。<p>
-     * 用于处理一个物品同时属于多个 tag 的边界情况。
-     */
-    private @Nullable NamespacedKey findWithCanonicalExpansion(List<List<String>> grid) {
-        // 收集每个格子的所有可能规范形式
-        List<List<String>> perSlotCanonicals = new ArrayList<>();
-        for (List<String> row : grid) {
-            for (String concreteId : row) {
-                if (concreteId == null) {
-                    perSlotCanonicals.add(List.of());
-                } else {
-                    Set<String> canonicals = concreteToCanonical.get(concreteId);
-                    if (canonicals != null && !canonicals.isEmpty()) {
-                        perSlotCanonicals.add(new ArrayList<>(canonicals));
-                    } else {
-                        perSlotCanonicals.add(List.of(concreteId));
-                    }
-                }
-            }
-        }
-
-        // 收集所有非空格子的索引
-        List<Integer> nonEmptyIndices = new ArrayList<>();
-        for (int i = 0; i < perSlotCanonicals.size(); i++) {
-            if (!perSlotCanonicals.get(i).isEmpty()) {
-                nonEmptyIndices.add(i);
-            }
-        }
-
-        if (nonEmptyIndices.isEmpty()) {
+    private @Nullable NamespacedKey findRecipeKey(String finger) {
+        List<NamespacedKey> recipeKeys = fingerToRecipeKeys.get(finger);
+        if (recipeKeys == null || recipeKeys.isEmpty()) {
             return null;
         }
 
-        // 找到有多个规范形式的格子（需要尝试组合的）
-        List<Integer> multiIndices = nonEmptyIndices.stream()
-            .filter(i -> perSlotCanonicals.get(i).size() > 1)
-            .toList();
-
-        // 如果没有多选格子，说明之前已经匹配过了，直接返回 null
-        if (multiIndices.isEmpty()) {
-            return null;
-        }
-
-        // 回溯尝试所有多选格子的组合
-        int[] choices = new int[multiIndices.size()];
-        int cols = grid.isEmpty() ? 0 : grid.getFirst().size();
-
-        while (true) {
-            // 收集当前组合的规范形式，同时生成有序和无序指纹
-            List<String> currentCanonicals = new ArrayList<>();
-            StringBuilder shapedSb = new StringBuilder();
-            boolean first = true;
-            int multiIdx = 0;
-            for (int slotIdx : nonEmptyIndices) {
-                if (!first) {
-                    shapedSb.append('|');
-                }
-                first = false;
-                int row = slotIdx / cols;
-                int col = slotIdx % cols;
-                shapedSb.append('<').append(row).append(',').append(col).append(',');
-
-                boolean isMulti = multiIndices.contains(slotIdx);
-                String canonical;
-                if (isMulti) {
-                    canonical = perSlotCanonicals.get(slotIdx).get(choices[multiIdx]);
-                } else {
-                    canonical = perSlotCanonicals.get(slotIdx).getFirst();
-                }
-                shapedSb.append(canonical).append('>');
-                currentCanonicals.add(canonical);
-                if (isMulti) {
-                    multiIdx++;
-                }
-            }
-
-            // 尝试有序指纹
-            NamespacedKey key = fingerToRecipeKey.get(shapedSb.toString());
-            if (key != null) {
-                return key;
-            }
-
-            // 尝试无序指纹
-            List<String> sorted = new ArrayList<>(currentCanonicals);
-            sorted.sort(null);
-            String shapelessFinger = String.join("|", sorted);
-            key = fingerToRecipeKey.get(shapelessFinger);
-            if (key != null) {
-                return key;
-            }
-
-            // 递增选择
-            boolean overflow = true;
-            for (int i = 0; i < choices.length; i++) {
-                int maxChoice = perSlotCanonicals.get(multiIndices.get(i)).size();
-                choices[i]++;
-                if (choices[i] < maxChoice) {
-                    overflow = false;
-                    break;
-                }
-                choices[i] = 0;
-            }
-            if (overflow) {
-                break;
+        for (int i = recipeKeys.size() - 1; i >= 0; i--) {
+            NamespacedKey recipeKey = recipeKeys.get(i);
+            if (RecipeManager.INSTANCE.getRecipe(recipeKey) != null) {
+                return recipeKey;
             }
         }
-
         return null;
     }
+
+    private record SlotCandidate(int row, int col, List<String> candidates) {}
 
     // ====================== 生命周期 ======================
 
     @Override
     public void lifecycle(Object plugin, LifeCycle lifeCycle) {
         // 清空所有映射，由 BukkitRecipeRegister 在配方注册时自然重建
-        fingerToRecipeKey.clear();
+        fingerToRecipeKeys.clear();
         recipeKeyToFingers.clear();
+        recipeKeyToCanonicalMappings.clear();
+        canonicalMappingReferenceCounts.clear();
         concreteToCanonical.clear();
     }
 

--- a/core/src/main/java/pers/yufiria/craftorithm/recipe/util/RecipeFingerGenerator.java
+++ b/core/src/main/java/pers/yufiria/craftorithm/recipe/util/RecipeFingerGenerator.java
@@ -9,55 +9,57 @@ import pers.yufiria.craftorithm.item.ItemManager;
 import pers.yufiria.craftorithm.item.ItemPack;
 import pers.yufiria.craftorithm.item.NamespacedItemId;
 import pers.yufiria.craftorithm.item.NamespacedItemIdStack;
-import pers.yufiria.craftorithm.recipe.RecipeFingerManager;
 import pers.yufiria.craftorithm.util.RecipeUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * 配方指纹生成工具。<p>
- * 从配方 YAML 配置中解析 shape / ingredients，生成规范指纹字符串。
- * 同时处理 tag / itempack 的反查映射注册。
+ * 从配方 YAML 配置中解析 shape / ingredients，生成规范指纹字符串，
+ * 并返回该配方使用的 tag / itempack 反查映射。
  */
 public class RecipeFingerGenerator {
 
     /**
-     * 根据配方配置生成所有规范指纹。
-     * <ul>
-     *   <li>有序配方 (有 shape 字段): 生成原始 + 水平翻转两条指纹</li>
-     *   <li>无序配方 (无 shape 字段): 生成一条排序后的指纹</li>
-     * </ul>
-     *
-     * @param recipeConfig 配方 YAML 配置
-     * @return 规范指纹列表，无法解析时返回空列表
+     * 根据配方配置生成规范指纹和反查映射。
      */
-    public static List<String> generateFingers(YamlConfiguration recipeConfig) {
+    public static GenerationResult generate(YamlConfiguration recipeConfig) {
+        Set<CanonicalMapping> canonicalMappings = new LinkedHashSet<>();
         List<String> shape = recipeConfig.getStringList("shape");
+        List<String> fingers;
 
         if (!shape.isEmpty()) {
-            // 有序配方：ingredients 是 ConfigurationSection (key=字符, value=choice字符串)
             ConfigurationSection ingredientsConfig = recipeConfig.getConfigurationSection("ingredients");
             if (ingredientsConfig == null) {
-                return List.of();
+                return GenerationResult.EMPTY;
             }
-            return generateShapedFingers(shape, ingredientsConfig);
+            fingers = generateShapedFingers(shape, ingredientsConfig, canonicalMappings);
         } else {
-            // 无序配方：ingredients 是 List<String>
             List<String> ingredientList = recipeConfig.getStringList("ingredients");
             if (ingredientList.isEmpty()) {
-                return List.of();
+                return GenerationResult.EMPTY;
             }
-            return generateShapelessFingers(ingredientList);
+            fingers = generateShapelessFingers(ingredientList, canonicalMappings);
         }
+
+        if (fingers.isEmpty()) {
+            return GenerationResult.EMPTY;
+        }
+        return new GenerationResult(List.copyOf(fingers), Set.copyOf(canonicalMappings));
     }
 
     // ====================== 有序配方 ======================
 
-    /**
-     * 生成有序配方的规范指纹（原始 + 水平翻转）。
-     */
-    private static List<String> generateShapedFingers(List<String> shape, ConfigurationSection ingredientsConfig) {
-        // 去除首尾空白行（复用 RecipeUtils 的逻辑）
+    private static List<String> generateShapedFingers(
+        List<String> shape,
+        ConfigurationSection ingredientsConfig,
+        Set<CanonicalMapping> canonicalMappings
+    ) {
         List<String> trimmedShape = new ArrayList<>(shape);
         RecipeUtils.removeEmptyRow(trimmedShape);
         RecipeUtils.removeEmptyColumn(trimmedShape);
@@ -68,33 +70,26 @@ public class RecipeFingerGenerator {
 
         int rows = trimmedShape.size();
         int cols = trimmedShape.stream().mapToInt(String::length).max().orElse(0);
-
-        // 解析每个格子的规范形式
         String[][] canonicalGrid = new String[rows][cols];
         for (int row = 0; row < rows; row++) {
             String rowStr = trimmedShape.get(row);
             for (int col = 0; col < cols; col++) {
                 if (col >= rowStr.length()) {
-                    canonicalGrid[row][col] = null;
                     continue;
                 }
                 char c = rowStr.charAt(col);
                 if (c == ' ') {
-                    canonicalGrid[row][col] = null;
                     continue;
                 }
                 String choiceStr = ingredientsConfig.getString(String.valueOf(c));
                 if (choiceStr == null) {
-                    canonicalGrid[row][col] = null;
                     continue;
                 }
-                canonicalGrid[row][col] = toCanonicalForm(choiceStr);
+                canonicalGrid[row][col] = toCanonicalForm(choiceStr, canonicalMappings);
             }
         }
 
-        // 生成原始指纹
         String original = buildShapedFinger(canonicalGrid, rows, cols, false);
-        // 生成水平翻转指纹
         String flipped = buildShapedFinger(canonicalGrid, rows, cols, true);
 
         List<String> fingers = new ArrayList<>(2);
@@ -107,14 +102,6 @@ public class RecipeFingerGenerator {
         return fingers;
     }
 
-    /**
-     * 构建有序配方的指纹字符串。
-     *
-     * @param grid   规范形式网格
-     * @param rows   行数
-     * @param cols   列数
-     * @param flip   是否水平翻转
-     */
     private static @Nullable String buildShapedFinger(String[][] grid, int rows, int cols, boolean flip) {
         StringBuilder sb = new StringBuilder();
         boolean first = true;
@@ -137,44 +124,34 @@ public class RecipeFingerGenerator {
 
     // ====================== 无序配方 ======================
 
-    /**
-     * 生成无序配方的规范指纹（排序，无坐标）。
-     */
-    private static List<String> generateShapelessFingers(List<String> ingredientList) {
+    private static List<String> generateShapelessFingers(
+        List<String> ingredientList,
+        Set<CanonicalMapping> canonicalMappings
+    ) {
         List<String> canonicals = new ArrayList<>();
         for (String choiceStr : ingredientList) {
             if (choiceStr == null || choiceStr.isEmpty()) {
                 continue;
             }
-            canonicals.add(toCanonicalForm(choiceStr));
+            canonicals.add(toCanonicalForm(choiceStr, canonicalMappings));
         }
 
         if (canonicals.isEmpty()) {
             return List.of();
         }
 
-        // 按字典序排序
         canonicals.sort(null);
-        String finger = String.join("|", canonicals);
-        return List.of(finger);
+        return List.of(String.join("|", canonicals));
     }
 
     // ====================== 规范化 ======================
 
-    /**
-     * 将配方配置中的 choice 字符串转为规范形式。<p>
-     * 同时为 tag / itempack 注册反查映射。
-     *
-     * @param choiceStr 配方配置中的材料字符串
-     * @return 规范形式字符串
-     */
-    public static String toCanonicalForm(String choiceStr) {
+    private static String toCanonicalForm(String choiceStr, Set<CanonicalMapping> canonicalMappings) {
         if (choiceStr == null || choiceStr.isEmpty()) {
             return choiceStr;
         }
 
         if (!choiceStr.contains(":")) {
-            // 无命名空间，标准化为 minecraft:
             Material material = Material.matchMaterial(choiceStr);
             if (material != null) {
                 return NamespacedItemId.fromMaterial(material).toString();
@@ -186,59 +163,60 @@ public class RecipeFingerGenerator {
         String namespace = choiceStr.substring(0, index).toLowerCase(Locale.ROOT);
         String body = choiceStr.substring(index + 1);
 
-        switch (namespace) {
-            case "minecraft":
-                // 标准化 material 名称
+        return switch (namespace) {
+            case "minecraft" -> {
                 Material material = Material.matchMaterial(choiceStr);
                 if (material != null) {
-                    return NamespacedItemId.fromMaterial(material).toString();
+                    yield NamespacedItemId.fromMaterial(material).toString();
                 }
-                return choiceStr.toLowerCase(Locale.ROOT);
-
-            case "tag":
-                // tag:minecraft:planks → 注册反查映射
-                registerTagMappings(choiceStr);
-                return choiceStr;
-
-            case "item_pack":
-                // item_pack:my_pack → 注册反查映射
-                registerItemPackMappings(choiceStr, body);
-                return choiceStr;
-
-            default:
-                // 自定义物品 (itemsadder:ruby 等)，保持原样，不改变大小写
-                return choiceStr;
-        }
+                yield choiceStr.toLowerCase(Locale.ROOT);
+            }
+            case "tag" -> {
+                registerTagMappings(choiceStr, canonicalMappings);
+                yield choiceStr;
+            }
+            case "item_pack" -> {
+                registerItemPackMappings(choiceStr, body, canonicalMappings);
+                yield choiceStr;
+            }
+            default -> choiceStr;
+        };
     }
 
-    /**
-     * 为 tag 注册所有 Material 的反查映射。
-     */
-    private static void registerTagMappings(String tagChoiceStr) {
+    private static void registerTagMappings(String tagChoiceStr, Set<CanonicalMapping> canonicalMappings) {
         String tagKeyStr = tagChoiceStr.substring("tag:".length());
         Optional<Tag<Material>> tagOpt = RecipeUtils.getTag(tagKeyStr);
         if (tagOpt.isEmpty()) {
             return;
         }
-        Tag<Material> tag = tagOpt.get();
-        for (Material m : tag.getValues()) {
-            String concreteId = NamespacedItemId.fromMaterial(m).toString();
-            RecipeFingerManager.INSTANCE.registerCanonicalMapping(concreteId, tagChoiceStr);
+
+        for (Material material : tagOpt.get().getValues()) {
+            String concreteId = NamespacedItemId.fromMaterial(material).toString();
+            canonicalMappings.add(new CanonicalMapping(concreteId, tagChoiceStr));
         }
     }
 
-    /**
-     * 为 itempack 注册所有物品的反查映射。
-     */
-    private static void registerItemPackMappings(String packChoiceStr, String packId) {
+    private static void registerItemPackMappings(
+        String packChoiceStr,
+        String packId,
+        Set<CanonicalMapping> canonicalMappings
+    ) {
         ItemPack itemPack = ItemManager.INSTANCE.getItemPack(packId);
         if (itemPack == null) {
             return;
         }
+
         for (NamespacedItemIdStack stackedId : itemPack.itemIds()) {
-            String concreteId = stackedId.itemId().toString();
-            RecipeFingerManager.INSTANCE.registerCanonicalMapping(concreteId, packChoiceStr);
+            canonicalMappings.add(new CanonicalMapping(stackedId.itemId().toString(), packChoiceStr));
         }
+    }
+
+    public record CanonicalMapping(String concreteId, String canonicalForm) {}
+
+    public record GenerationResult(List<String> fingers, Set<CanonicalMapping> canonicalMappings) {
+
+        private static final GenerationResult EMPTY = new GenerationResult(List.of(), Set.of());
+
     }
 
 }

--- a/core/src/main/java/pers/yufiria/craftorithm/trigger/CraftTriggerTypes.java
+++ b/core/src/main/java/pers/yufiria/craftorithm/trigger/CraftTriggerTypes.java
@@ -13,6 +13,7 @@ import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.jetbrains.annotations.Nullable;
+import pers.yufiria.craftorithm.recipe.RecipeFingerManager;
 import pers.yufiria.craftorithm.recipe.RecipeManager;
 import pers.yufiria.craftorithm.recipe.RecipeType;
 import pers.yufiria.craftorithm.recipe.extra.AnvilRecipe;
@@ -46,11 +47,20 @@ public enum CraftTriggerTypes implements TriggerType {
         public @Nullable TriggerContext extractContext(Event event) {
             CraftItemEvent craftItemEvent = (CraftItemEvent) event;
             if (!(craftItemEvent.getWhoClicked() instanceof Player player)) return null;
-            Recipe recipe = craftItemEvent.getRecipe();
-            NamespacedKey recipeKey = RecipeManager.INSTANCE.getRecipeKey(recipe);
-            RecipeType recipeType = RecipeManager.INSTANCE.getRecipeType(recipe);
-            TriggerContext ctx = new TriggerContext(player.getUniqueId(), recipeKey, recipeType);
             @Nullable ItemStack[] matrix = craftItemEvent.getInventory().getMatrix();
+            Recipe recipe = craftItemEvent.getRecipe();
+            NamespacedKey recipeKey;
+            RecipeType recipeType;
+            if (recipe != null) {
+                recipeKey = RecipeManager.INSTANCE.getRecipeKey(recipe);
+                recipeType = RecipeManager.INSTANCE.getRecipeType(recipe);
+            } else {
+                recipeKey = matrix != null ? RecipeFingerManager.INSTANCE.findRecipeByGrid(matrix) : null;
+                if (recipeKey == null) return null;
+                Recipe fingerRecipe = RecipeManager.INSTANCE.getRecipe(recipeKey);
+                recipeType = fingerRecipe != null ? RecipeManager.INSTANCE.getRecipeType(fingerRecipe) : null;
+            }
+            TriggerContext ctx = new TriggerContext(player.getUniqueId(), recipeKey, recipeType);
             if (matrix != null) {
                 addIngredientsFromMatrix(ctx, matrix);
             }
@@ -67,12 +77,21 @@ public enum CraftTriggerTypes implements TriggerType {
         @Override
         public @Nullable TriggerContext extractPrepareContext(Event event) {
             PrepareItemCraftEvent prepareItemCraftEvent = (PrepareItemCraftEvent) event;
-            if (prepareItemCraftEvent.getRecipe() == null) return null;
             if (!(prepareItemCraftEvent.getInventory().getHolder() instanceof Player player)) return null;
-            NamespacedKey recipeKey = RecipeManager.INSTANCE.getRecipeKey(prepareItemCraftEvent.getRecipe());
-            RecipeType recipeType = RecipeManager.INSTANCE.getRecipeType(prepareItemCraftEvent.getRecipe());
-            TriggerContext ctx = new TriggerContext(player.getUniqueId(), recipeKey, recipeType);
             @Nullable ItemStack[] matrix = prepareItemCraftEvent.getInventory().getMatrix();
+            Recipe recipe = prepareItemCraftEvent.getRecipe();
+            NamespacedKey recipeKey;
+            RecipeType recipeType;
+            if (recipe != null) {
+                recipeKey = RecipeManager.INSTANCE.getRecipeKey(recipe);
+                recipeType = RecipeManager.INSTANCE.getRecipeType(recipe);
+            } else {
+                recipeKey = matrix != null ? RecipeFingerManager.INSTANCE.findRecipeByGrid(matrix) : null;
+                if (recipeKey == null) return null;
+                Recipe fingerRecipe = RecipeManager.INSTANCE.getRecipe(recipeKey);
+                recipeType = fingerRecipe != null ? RecipeManager.INSTANCE.getRecipeType(fingerRecipe) : null;
+            }
+            TriggerContext ctx = new TriggerContext(player.getUniqueId(), recipeKey, recipeType);
             if (matrix != null) {
                 addIngredientsFromMatrix(ctx, matrix);
             }

--- a/core/src/main/java/pers/yufiria/craftorithm/trigger/listener/CraftTriggerHandler.java
+++ b/core/src/main/java/pers/yufiria/craftorithm/trigger/listener/CraftTriggerHandler.java
@@ -22,7 +22,7 @@ public enum CraftTriggerHandler implements Listener {
     /**
      * Prepare 阶段：检查 deny 条件，清空结果槽拒绝合成
      */
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.LOW)
     public void onPrepareCraft(PrepareItemCraftEvent event) {
         TriggerContext ctx = CraftTriggerTypes.CRAFTING.extractPrepareContext(event);
         if (ctx == null) return;

--- a/core/src/main/java/pers/yufiria/craftorithm/util/EventUtils.java
+++ b/core/src/main/java/pers/yufiria/craftorithm/util/EventUtils.java
@@ -13,7 +13,9 @@ import org.bukkit.event.block.CrafterCraftEvent;
 import org.bukkit.event.inventory.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
+import org.jetbrains.annotations.Nullable;
 import pers.yufiria.craftorithm.config.PluginConfigs;
+import pers.yufiria.craftorithm.recipe.RecipeFingerManager;
 import pers.yufiria.craftorithm.recipe.RecipeManager;
 import pers.yufiria.craftorithm.recipe.extra.AnvilRecipe;
 import pers.yufiria.craftorithm.recipe.extra.AnvilRecipeHandler;
@@ -38,27 +40,41 @@ public class EventUtils {
     }
 
     public static boolean isCraftorithmRecipeEvent(Event event) {
+        return getCraftorithmRecipeKey(event) != null;
+    }
+
+    public static @Nullable NamespacedKey getCraftorithmRecipeKey(Event event) {
         Recipe recipe = null;
         switch (event) {
-            case CraftItemEvent craftItemEvent -> recipe = craftItemEvent.getRecipe();
-            case PrepareItemCraftEvent prepareItemCraftEvent -> recipe = prepareItemCraftEvent.getRecipe();
+            case CraftItemEvent craftItemEvent -> {
+                recipe = craftItemEvent.getRecipe();
+                if (recipe == null) {
+                    return RecipeFingerManager.INSTANCE.findRecipeByGrid(craftItemEvent.getInventory().getMatrix());
+                }
+            }
+            case PrepareItemCraftEvent prepareItemCraftEvent -> {
+                recipe = prepareItemCraftEvent.getRecipe();
+                if (recipe == null) {
+                    return RecipeFingerManager.INSTANCE.findRecipeByGrid(prepareItemCraftEvent.getInventory().getMatrix());
+                }
+            }
             case PrepareSmithingEvent prepareSmithingEvent -> recipe = prepareSmithingEvent.getInventory().getRecipe();
             case SmithItemEvent smithItemEvent -> recipe = smithItemEvent.getInventory().getRecipe();
             case FurnaceSmeltEvent furnaceSmeltEvent -> recipe = furnaceSmeltEvent.getRecipe();
             case BlockCookEvent blockCookEvent -> recipe = blockCookEvent.getRecipe();
             case PrepareAnvilEvent prepareAnvilEvent -> {
                 if (!PluginConfigs.ENABLE_ANVIL_RECIPE.value())
-                    return false;
+                    return null;
                 ItemStack base = prepareAnvilEvent.getInventory().getItem(0);
                 ItemStack addition = prepareAnvilEvent.getInventory().getItem(1);
                 if (ItemHelper.isAir(base) || ItemHelper.isAir(addition))
-                    return false;
+                    return null;
 
                 AnvilRecipe anvilRecipe = AnvilRecipeHandler.INSTANCE.matchAnvilRecipe(base, addition);
-                return anvilRecipe != null;
+                return anvilRecipe != null ? anvilRecipe.getKey() : null;
             }
             case null -> {
-                return false;
+                return null;
             }
             default -> {
                 if (MinecraftVersion.current().afterOrEquals(MinecraftVersion.V1_17_1)) {
@@ -80,10 +96,18 @@ public class EventUtils {
                 }
             }
         }
+        return getCraftorithmRecipeKey(recipe);
+    }
+
+    public static @Nullable NamespacedKey getCraftorithmRecipeKey(@Nullable Recipe recipe) {
         if (recipe == null) {
-            return false;
+            return null;
         }
         NamespacedKey recipeKey = RecipeManager.INSTANCE.getRecipeKey(recipe);
+        return isCraftorithmRecipeKey(recipeKey) ? recipeKey : null;
+    }
+
+    public static boolean isCraftorithmRecipeKey(@Nullable NamespacedKey recipeKey) {
         return recipeKey != null && recipeKey.getNamespace().equals(RecipeManager.INSTANCE.PLUGIN_RECIPE_NAMESPACE);
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 crypticlibVer=1.19.0.0
-pluginVer=1.11.4.1
+pluginVer=1.11.4.2


### PR DESCRIPTION
## Summary
- 将工作台指纹匹配改为确定性候选展开：具体物品 ID 优先、canonical 候选稳定排序，并限制最大组合数。
- 支持同指纹多配方的后注册优先策略，并通过引用计数正确维护 tag / itempack canonical 映射生命周期。
- 补齐 CraftItemEvent、PrepareItemCraftEvent 和事件工具类在 Bukkit Recipe 缺失时的指纹回退识别，同时调整 Prepare 监听优先级并更新版本号。

## Test plan
- [x] `./gradlew :core:compileJava`
- [x] `./gradlew build`
- [ ] 在真实 Paper 服务器验证 tag、itempack、镜像、多 canonical、同指纹覆盖、reload/unload、shift-click 和配方书交互路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)