### PR TITLE
fix(recipe): 修复指纹配方合成后材料翻倍

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(project(":hook:protocollib"))
     implementation(project(":hook:vault"))
     implementation(project(":hook:playerpoints"))
+    implementation(project(":nms:v1_20_1"))
     implementation("com.crypticlib:bukkit:${rootProject.findProperty("crypticlibVer")}")
 }
 

--- a/core/src/main/java/pers/yufiria/craftorithm/Craftorithm.java
+++ b/core/src/main/java/pers/yufiria/craftorithm/Craftorithm.java
@@ -18,6 +18,7 @@ import pers.yufiria.craftorithm.bstat.Metrics;
 import pers.yufiria.craftorithm.config.Languages;
 import pers.yufiria.craftorithm.config.PluginConfigs;
 import pers.yufiria.craftorithm.exception.UnsupportedVersionException;
+import pers.yufiria.craftorithm.nms.CraftingMenuCurrentRecipeSetters;
 import pers.yufiria.craftorithm.recipe.RecipeManager;
 import pers.yufiria.craftorithm.recipe.RecipeType;
 import pers.yufiria.craftorithm.script.ActionModule;
@@ -50,6 +51,7 @@ public final class Craftorithm extends BukkitPlugin implements LifeCycleTask {
             BukkitMsgSender.INSTANCE.info("&cUnsupported Version");
             throw new UnsupportedVersionException();
         }
+        CraftingMenuCurrentRecipeSetters.INSTANCE.load();
     }
 
     @Override

--- a/core/src/main/java/pers/yufiria/craftorithm/listener/CraftingHandler.java
+++ b/core/src/main/java/pers/yufiria/craftorithm/listener/CraftingHandler.java
@@ -1,8 +1,6 @@
 package pers.yufiria.craftorithm.listener;
 
 import crypticlib.listener.EventListener;
-import crypticlib.util.IOHelper;
-import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.Inventory;
@@ -17,6 +15,7 @@ import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import pers.yufiria.craftorithm.item.ItemManager;
+import pers.yufiria.craftorithm.nms.CraftingMenuCurrentRecipeSetters;
 import pers.yufiria.craftorithm.recipe.finger.RecipeFingerManager;
 import pers.yufiria.craftorithm.recipe.RecipeManager;
 
@@ -44,6 +43,7 @@ public enum CraftingHandler implements Listener {
         if (fingerRecipeKey != null) {
             Recipe fingerRecipe = RecipeManager.INSTANCE.getRecipe(fingerRecipeKey);
             if (fingerRecipe != null) {
+                CraftingMenuCurrentRecipeSetters.INSTANCE.setCurrentRecipe(event.getInventory(), fingerRecipeKey, fingerRecipe);
                 event.getInventory().setResult(fingerRecipe.getResult().clone());
                 refreshResultItem(event, event.getInventory().getResult());
                 new PrepareItemCraftByFingerEvent(event, fingerRecipeKey).call();
@@ -69,11 +69,6 @@ public enum CraftingHandler implements Listener {
         if (fingerRecipeKey != null) {
             new CraftItemByFingerEvent(craftingInventory, fingerRecipeKey, event).call();
         }
-    }
-
-    @EventHandler
-    public void onCraft(CraftItemEvent event) {
-        IOHelper.info("1");
     }
 
     private void refreshResultItem(PrepareItemCraftEvent event, ItemStack item) {

--- a/core/src/main/java/pers/yufiria/craftorithm/nms/CraftingMenuCurrentRecipeSetters.java
+++ b/core/src/main/java/pers/yufiria/craftorithm/nms/CraftingMenuCurrentRecipeSetters.java
@@ -1,0 +1,33 @@
+package pers.yufiria.craftorithm.nms;
+
+import crypticlib.MinecraftVersion;
+import crypticlib.util.IOHelper;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.CraftingInventory;
+import org.bukkit.inventory.Recipe;
+
+public enum CraftingMenuCurrentRecipeSetters {
+
+    INSTANCE;
+
+    private CraftingMenuCurrentRecipeSetter setter;
+
+    public void load() {
+        setter = null;
+        if (MinecraftVersion.current() != MinecraftVersion.V1_20_1) {
+            return;
+        }
+        try {
+            Class<?> setterClass = Class.forName("pers.yufiria.craftorithm.nms.V1_20_1CraftingMenuCurrentRecipeSetter");
+            setter = (CraftingMenuCurrentRecipeSetter) setterClass.getField("INSTANCE").get(null);
+        } catch (ReflectiveOperationException | LinkageError throwable) {
+            IOHelper.info("&cFailed to load crafting recipe NMS bridge for 1.20.1");
+            throwable.printStackTrace();
+        }
+    }
+
+    public boolean setCurrentRecipe(CraftingInventory craftingInventory, NamespacedKey recipeKey, Recipe recipe) {
+        return setter != null && setter.setCurrentRecipe(craftingInventory, recipeKey, recipe);
+    }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 crypticlibVer=1.19.0.0
-pluginVer=1.11.4.2
+pluginVer=1.11.4.3

--- a/nms/v1_20_1/src/main/java/pers/yufiria/craftorithm/nms/V1_20_1CraftingMenuCurrentRecipeSetter.java
+++ b/nms/v1_20_1/src/main/java/pers/yufiria/craftorithm/nms/V1_20_1CraftingMenuCurrentRecipeSetter.java
@@ -1,63 +1,156 @@
 package pers.yufiria.craftorithm.nms;
 
-import crypticlib.lifecycle.LifeCycle;
-import crypticlib.lifecycle.LifeCycleTaskSettings;
-import crypticlib.lifecycle.TaskRule;
 import net.minecraft.core.NonNullList;
+import net.minecraft.resources.MinecraftKey;
+import net.minecraft.world.inventory.InventoryCrafting;
+import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.IRecipe;
 import net.minecraft.world.item.crafting.RecipeItemStack;
 import net.minecraft.world.item.crafting.ShapedRecipes;
+import net.minecraft.world.item.crafting.ShapelessRecipes;
+import net.minecraft.world.level.World;
+import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.craftbukkit.v1_20_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftInventoryCrafting;
 import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftRecipe;
 import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftShapedRecipe;
+import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftShapelessRecipe;
 import org.bukkit.craftbukkit.v1_20_R1.util.CraftNamespacedKey;
 import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
+import pers.yufiria.craftorithm.recipe.finger.RecipeFingerManager;
 
+import java.util.List;
 import java.util.Map;
 
-@LifeCycleTaskSettings(
-    rules = {@TaskRule(lifeCycle = LifeCycle.LOAD)}
-)
 public enum V1_20_1CraftingMenuCurrentRecipeSetter implements CraftingMenuCurrentRecipeSetter {
 
     INSTANCE;
 
     @Override
     public boolean setCurrentRecipe(CraftingInventory craftingInventory, NamespacedKey recipeKey, Recipe recipe) {
-        if (!(recipe instanceof ShapedRecipe shapedRecipe)) {
+        IRecipe<InventoryCrafting> nmsRecipe = switch (recipe) {
+            case ShapedRecipe shapedRecipe -> createShapedRecipe(recipeKey, shapedRecipe);
+            case ShapelessRecipe shapelessRecipe -> createShapelessRecipe(recipeKey, shapelessRecipe);
+            default -> null;
+        };
+        if (nmsRecipe == null) {
             return false;
         }
-        CraftShapedRecipe craftShapedRecipe = CraftShapedRecipe.fromBukkitRecipe(shapedRecipe);
-        String[] shape = craftShapedRecipe.getShape();
-        Map<Character, RecipeChoice> ingredients = craftShapedRecipe.getChoiceMap();
+
+        MinecraftKey nmsRecipeKey = CraftNamespacedKey.toMinecraft(recipeKey);
+        var recipeManager = ((CraftServer) Bukkit.getServer()).getServer().aE();
+        recipeManager.removeRecipe(nmsRecipeKey);
+        recipeManager.addRecipe(nmsRecipe);
+        ((CraftInventoryCrafting) craftingInventory).getMatrixInventory().setCurrentRecipe(nmsRecipe);
+        return true;
+    }
+
+    private ShapedRecipes createShapedRecipe(NamespacedKey recipeKey, ShapedRecipe shapedRecipe) {
+        CraftShapedRecipe craftRecipe = CraftShapedRecipe.fromBukkitRecipe(shapedRecipe);
+        String[] shape = craftRecipe.getShape();
+        Map<Character, RecipeChoice> ingredients = craftRecipe.getChoiceMap();
         int width = shape[0].length();
         NonNullList<RecipeItemStack> data = NonNullList.a(shape.length * width, RecipeItemStack.a);
 
-        for(int i = 0; i < shape.length; ++i) {
-            String row = shape[i];
-
-            for(int j = 0; j < row.length(); ++j) {
-                data.set(i * width + j, craftShapedRecipe.toNMS(ingredients.get(row.charAt(j)), false));
+        for (int rowIndex = 0; rowIndex < shape.length; rowIndex++) {
+            String row = shape[rowIndex];
+            for (int columnIndex = 0; columnIndex < row.length(); columnIndex++) {
+                data.set(
+                    rowIndex * width + columnIndex,
+                    craftRecipe.toNMS(ingredients.get(row.charAt(columnIndex)), false)
+                );
             }
         }
 
-        ShapedRecipes nmsShapedRecipe = new ShapedRecipes(
+        return new FingerShapedRecipe(
+            recipeKey,
             CraftNamespacedKey.toMinecraft(recipeKey),
-            craftShapedRecipe.getGroup(),
-            CraftRecipe.getCategory(
-                craftShapedRecipe.getCategory()
-            ),
+            craftRecipe.getGroup(),
+            CraftRecipe.getCategory(craftRecipe.getCategory()),
             width,
             shape.length,
             data,
-            CraftItemStack.asNMSCopy(craftingInventory.getResult())
+            CraftItemStack.asNMSCopy(shapedRecipe.getResult())
         );
-
-        ((CraftInventoryCrafting) craftingInventory).getMatrixInventory().setCurrentRecipe(nmsShapedRecipe);
-        return false;
     }
+
+    private ShapelessRecipes createShapelessRecipe(NamespacedKey recipeKey, ShapelessRecipe shapelessRecipe) {
+        CraftShapelessRecipe craftRecipe = CraftShapelessRecipe.fromBukkitRecipe(shapelessRecipe);
+        List<RecipeChoice> ingredients = craftRecipe.getChoiceList();
+        NonNullList<RecipeItemStack> data = NonNullList.a(ingredients.size(), RecipeItemStack.a);
+        for (int index = 0; index < ingredients.size(); index++) {
+            data.set(index, craftRecipe.toNMS(ingredients.get(index), false));
+        }
+
+        return new FingerShapelessRecipe(
+            recipeKey,
+            CraftNamespacedKey.toMinecraft(recipeKey),
+            craftRecipe.getGroup(),
+            CraftRecipe.getCategory(craftRecipe.getCategory()),
+            CraftItemStack.asNMSCopy(shapelessRecipe.getResult()),
+            data
+        );
+    }
+
+    private static boolean matchesFinger(NamespacedKey recipeKey, InventoryCrafting inventory) {
+        List<net.minecraft.world.item.ItemStack> contents = inventory.h();
+        org.bukkit.inventory.ItemStack[] matrix = new org.bukkit.inventory.ItemStack[contents.size()];
+        for (int index = 0; index < contents.size(); index++) {
+            matrix[index] = CraftItemStack.asBukkitCopy(contents.get(index));
+        }
+        return recipeKey.equals(RecipeFingerManager.INSTANCE.findRecipeByGrid(matrix));
+    }
+
+    private static final class FingerShapedRecipe extends ShapedRecipes {
+
+        private final NamespacedKey recipeKey;
+
+        private FingerShapedRecipe(
+            NamespacedKey recipeKey,
+            MinecraftKey nmsRecipeKey,
+            String group,
+            CraftingBookCategory category,
+            int width,
+            int height,
+            NonNullList<RecipeItemStack> ingredients,
+            net.minecraft.world.item.ItemStack result
+        ) {
+            super(nmsRecipeKey, group, category, width, height, ingredients, result);
+            this.recipeKey = recipeKey;
+        }
+
+        @Override
+        public boolean a(InventoryCrafting inventory, World world) {
+            return matchesFinger(recipeKey, inventory);
+        }
+    }
+
+    private static final class FingerShapelessRecipe extends ShapelessRecipes {
+
+        private final NamespacedKey recipeKey;
+
+        private FingerShapelessRecipe(
+            NamespacedKey recipeKey,
+            MinecraftKey nmsRecipeKey,
+            String group,
+            CraftingBookCategory category,
+            net.minecraft.world.item.ItemStack result,
+            NonNullList<RecipeItemStack> ingredients
+        ) {
+            super(nmsRecipeKey, group, category, result, ingredients);
+            this.recipeKey = recipeKey;
+        }
+
+        @Override
+        public boolean a(InventoryCrafting inventory, World world) {
+            return matchesFinger(recipeKey, inventory);
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- 修复指纹配方未被原生 RecipeManager 命中时，remainder 复用输入 `ItemStack` 引用导致材料翻倍的问题
- 让 1.20.1 的有序与无序指纹配方真正参与 NMS 配方匹配，并将对应 NMS 模块打入主插件产物
- 删除遗留调试输出并将插件补丁版本更新至 `1.11.4.3`

## Test plan
- [x] 运行 `./gradlew :core:compileJava :nms:v1_20_1:compileJava`
- [x] 运行 `./gradlew build`
- [x] 确认主 JAR 包含 NMS 桥接及 1.20.1 实现
- [ ] 在真实 1.20.1 服务端验证普通点击合成不会使输入材料翻倍
- [ ] 在真实 1.20.1 服务端验证 Shift 批量合成的产物与材料消耗数量正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)