### PR TITLE
fix crashes in sound action, map iterator state, and tab completion

### DIFF
--- a/core/src/main/java/pers/yufiria/craftorithm/command/recipe/DisplayCommand.java
+++ b/core/src/main/java/pers/yufiria/craftorithm/command/recipe/DisplayCommand.java
@@ -84,7 +84,7 @@ public class DisplayCommand extends CommandNode {
     public @Nullable List<String> tabComplete(@NotNull Invoker invoker, List<String> args) {
         if (args.size() <= 1) {
             Set<NamespacedKey> recipes = new LinkedHashSet<>(RecipeManager.INSTANCE.craftorithmRecipes().keySet());
-            recipes.addAll(RecipeManager.INSTANCE.craftorithmRecipes().keySet());
+            recipes.addAll(RecipeManager.INSTANCE.serverRecipeKeys());
             return recipes.stream().map(NamespacedKey::toString).toList();
         } else if (args.size() == 2) {
             return Bukkit.getOnlinePlayers().stream().map(Player::getName).toList();

--- a/core/src/main/java/pers/yufiria/craftorithm/recipe/RecipeTypeMap.java
+++ b/core/src/main/java/pers/yufiria/craftorithm/recipe/RecipeTypeMap.java
@@ -256,6 +256,7 @@ public class RecipeTypeMap<K extends RecipeType, V> implements Map<K, V> {
     private class KeyIterator implements Iterator<K> {
         private int cursor = 0;      // 下一个要检查的位置
         private int nextIndex = -1;  // 找到的下一个有效索引
+        private int lastRet = -1;
 
         @Override
         public boolean hasNext() {
@@ -280,16 +281,16 @@ public class RecipeTypeMap<K extends RecipeType, V> implements Map<K, V> {
         @SuppressWarnings("unchecked")
         public K next() {
             if (!hasNext()) throw new NoSuchElementException();
-            K result = (K) keys[nextIndex];
+            lastRet = nextIndex;
             nextIndex = -1;
-            return result;
+            return (K) keys[lastRet];
         }
 
         @Override
         public void remove() {
-            if (nextIndex == -1) throw new IllegalStateException();
-            RecipeTypeMap.this.remove(keys[nextIndex]);
-            nextIndex = -1;
+            if (lastRet == -1) throw new IllegalStateException();
+            RecipeTypeMap.this.remove(keys[lastRet]);
+            lastRet = -1;
         }
     }
 
@@ -297,6 +298,7 @@ public class RecipeTypeMap<K extends RecipeType, V> implements Map<K, V> {
     private class ValuesIterator implements Iterator<V> {
         private int cursor = 0;
         private int nextIndex = -1;
+        private int lastRet = -1;
 
         @Override
         public boolean hasNext() {
@@ -321,7 +323,8 @@ public class RecipeTypeMap<K extends RecipeType, V> implements Map<K, V> {
         @SuppressWarnings("unchecked")
         public V next() {
             if (!hasNext()) throw new NoSuchElementException();
-            Object value = table[nextIndex];
+            lastRet = nextIndex;
+            Object value = table[lastRet];
             V result = (value == NULL_VALUE) ? null : (V) value;
             nextIndex = -1;
             return result;
@@ -329,9 +332,9 @@ public class RecipeTypeMap<K extends RecipeType, V> implements Map<K, V> {
 
         @Override
         public void remove() {
-            if (nextIndex == -1) throw new IllegalStateException();
-            RecipeTypeMap.this.remove(keys[nextIndex]); // 通过键删除
-            nextIndex = -1;
+            if (lastRet == -1) throw new IllegalStateException();
+            RecipeTypeMap.this.remove(keys[lastRet]); // 通过键删除
+            lastRet = -1;
         }
     }
 
@@ -339,6 +342,7 @@ public class RecipeTypeMap<K extends RecipeType, V> implements Map<K, V> {
     private class EntryIterator implements Iterator<Entry<K, V>> {
         private int cursor = 0;
         private int nextIndex = -1;
+        private int lastRet = -1;
 
         @Override
         public boolean hasNext() {
@@ -363,8 +367,9 @@ public class RecipeTypeMap<K extends RecipeType, V> implements Map<K, V> {
         @SuppressWarnings("unchecked")
         public Entry<K, V> next() {
             if (!hasNext()) throw new NoSuchElementException();
-            K key = (K) keys[nextIndex];
-            Object value = table[nextIndex];
+            lastRet = nextIndex;
+            K key = (K) keys[lastRet];
+            Object value = table[lastRet];
             V actualValue = (value == NULL_VALUE) ? null : (V) value;
             Entry<K, V> entry = new AbstractMap.SimpleImmutableEntry<>(key, actualValue);
             nextIndex = -1;
@@ -373,9 +378,9 @@ public class RecipeTypeMap<K extends RecipeType, V> implements Map<K, V> {
 
         @Override
         public void remove() {
-            if (nextIndex == -1) throw new IllegalStateException();
-            RecipeTypeMap.this.remove(keys[nextIndex]);
-            nextIndex = -1;
+            if (lastRet == -1) throw new IllegalStateException();
+            RecipeTypeMap.this.remove(keys[lastRet]);
+            lastRet = -1;
         }
     }
 }

--- a/core/src/main/java/pers/yufiria/craftorithm/script/ActionModule.java
+++ b/core/src/main/java/pers/yufiria/craftorithm/script/ActionModule.java
@@ -350,7 +350,11 @@ public enum ActionModule implements ScriptModule {
         float volume = args.length > 1 ? (float) args[1].asNumber() : 1.0f;
         float pitch = args.length > 2 ? (float) args[2].asNumber() : 1.0f;
         if (MinecraftVersion.current().afterOrEquals(MinecraftVersion.V1_21_4)) {
-            Sound sound = Registry.SOUNDS.get(Objects.requireNonNull(NamespacedKey.fromString(soundName)));
+            NamespacedKey soundKey = NamespacedKey.fromString(soundName);
+            if (soundKey == null) {
+                return ScriptValue.nil();
+            }
+            Sound sound = Registry.SOUNDS.get(soundKey);
             if (sound == null) {
                 return ScriptValue.nil();
             }


### PR DESCRIPTION
* Fixed server recipe keys omitted from `display` command tab completion due to set insertion duplicate
* Fixed `NullPointerException` crash in `sound` script action on MC 1.21.4+ when passed unparseable sound strings
* Fixed `IllegalStateException` thrown during element removal in `RecipeTypeMap` iterator implementations by correctly tracking previously returned elements